### PR TITLE
Add missing math.h include.

### DIFF
--- a/src/algorithms/lp/Problem.cpp
+++ b/src/algorithms/lp/Problem.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <boost/filesystem.hpp>
 #include <base-logging/Logging.hpp>
+#include <math.h>
 
 namespace graph_analysis {
 namespace algorithms {


### PR DESCRIPTION
Include math.h because `fabs` is used.